### PR TITLE
Duration calculation refactor

### DIFF
--- a/.idea/gb_working_day.iml
+++ b/.idea/gb_working_day.iml
@@ -2,42 +2,144 @@
 <module type="RUBY_MODULE" version="4">
   <component name="FacetManager">
     <facet type="gem" name="Ruby Gem">
-      <configuration />
+      <configuration>
+        <option name="GEM_APP_ROOT_PATH" value="$MODULE_DIR$" />
+        <option name="GEM_APP_TEST_PATH" value="" />
+        <option name="GEM_APP_LIB_PATH" value="$MODULE_DIR$/lib" />
+      </configuration>
     </facet>
   </component>
   <component name="ModuleRunConfigurationManager">
-    <shared>
-      <configuration default="false" name="specs" type="RSpecRunConfigurationType" factoryName="RSpec">
-        <module name="gb_working_day" />
-        <predefined_log_file enabled="true" id="RUBY_RSPEC" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
-        <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
-        <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
-          <COVERAGE_PATTERN ENABLED="true">
-            <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
-          </COVERAGE_PATTERN>
-        </EXTENSION>
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="$MODULE_DIR$/spec" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="ALL_IN_FOLDER" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
-        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
-        <method v="2" />
-      </configuration>
-    </shared>
+    <configuration default="false" name="specs" type="RSpecRunConfigurationType" factoryName="RSpec">
+      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
+      <module name="gb_working_day" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs />
+      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
+      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="$MODULE_DIR$/spec" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="ALL_IN_FOLDER" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method />
+    </configuration>
+    <configuration default="false" name="Date extensions should properly add work duration: gb_working_day" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true">
+      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
+      <module name="gb_working_day" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
+      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/core_ext/date_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="Date extensions should properly add work duration" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method />
+    </configuration>
+    <configuration default="false" name="GBWorkDay::Date should return work day duration on subtraction: gb_working_day" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true">
+      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
+      <module name="gb_working_day" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
+      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/helpers/date_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="GBWorkDay::Date should return work day duration on subtraction" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method />
+    </configuration>
+    <configuration default="false" name="Time extensions should properly add work duration: gb_working_day" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true">
+      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
+      <module name="gb_working_day" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+      <envs>
+        <env name="JRUBY_OPTS" value="-X+O" />
+      </envs>
+      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
+      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
+      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
+        <COVERAGE_PATTERN ENABLED="true">
+          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+        </COVERAGE_PATTERN>
+      </EXTENSION>
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/core_ext/time_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="Time extensions should properly add work duration" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+      <method />
+    </configuration>
   </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
@@ -45,26 +147,23 @@
       <excludeFolder url="file://$MODULE_DIR$/.bundle" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/bundle" />
     </content>
-    <orderEntry type="jdk" jdkName="RVM: ruby-2.5.1" jdkType="RUBY_SDK" />
+    <orderEntry type="jdk" jdkName="RVM: ruby-2.3.0" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="activesupport (v5.2.2, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.17.1, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.1.4, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.3, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="docile (v1.3.1, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.3.0, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="json (v2.1.0, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.11.3, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rake (v10.5.0, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.8.2, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.16.1, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.10.2, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="thread_safe (v0.3.6, RVM: ruby-2.5.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v1.2.5, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activesupport (v4.2.6, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.2.5, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="docile (v1.1.5, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="i18n (v0.7.0, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.9.0, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v10.5.0, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.1.0, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.1.7, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.1.2, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.1.3, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.1.2, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.10.0, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.10.0, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="thread_safe (v0.3.5, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v1.2.2, RVM: ruby-2.3.0) [gem]" level="application" />
   </component>
   <component name="RModuleSettingsStorage">
     <LOAD_PATH number="1" string0="$MODULE_DIR$/lib" />

--- a/.idea/gb_working_day.iml
+++ b/.idea/gb_working_day.iml
@@ -2,144 +2,42 @@
 <module type="RUBY_MODULE" version="4">
   <component name="FacetManager">
     <facet type="gem" name="Ruby Gem">
-      <configuration>
-        <option name="GEM_APP_ROOT_PATH" value="$MODULE_DIR$" />
-        <option name="GEM_APP_TEST_PATH" value="" />
-        <option name="GEM_APP_LIB_PATH" value="$MODULE_DIR$/lib" />
-      </configuration>
+      <configuration />
     </facet>
   </component>
   <component name="ModuleRunConfigurationManager">
-    <configuration default="false" name="specs" type="RSpecRunConfigurationType" factoryName="RSpec">
-      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
-      <module name="gb_working_day" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-      <envs />
-      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
-      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
-      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
-        <COVERAGE_PATTERN ENABLED="true">
-          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
-        </COVERAGE_PATTERN>
-      </EXTENSION>
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="$MODULE_DIR$/spec" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="ALL_IN_FOLDER" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
-      <method />
-    </configuration>
-    <configuration default="false" name="Date extensions should properly add work duration: gb_working_day" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true">
-      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
-      <module name="gb_working_day" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-      <envs>
-        <env name="JRUBY_OPTS" value="-X+O" />
-      </envs>
-      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
-      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
-      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
-        <COVERAGE_PATTERN ENABLED="true">
-          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
-        </COVERAGE_PATTERN>
-      </EXTENSION>
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/core_ext/date_spec.rb" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="Date extensions should properly add work duration" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
-      <method />
-    </configuration>
-    <configuration default="false" name="GBWorkDay::Date should return work day duration on subtraction: gb_working_day" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true">
-      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
-      <module name="gb_working_day" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-      <envs>
-        <env name="JRUBY_OPTS" value="-X+O" />
-      </envs>
-      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
-      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
-      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
-        <COVERAGE_PATTERN ENABLED="true">
-          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
-        </COVERAGE_PATTERN>
-      </EXTENSION>
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/helpers/date_spec.rb" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="GBWorkDay::Date should return work day duration on subtraction" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
-      <method />
-    </configuration>
-    <configuration default="false" name="Time extensions should properly add work duration: gb_working_day" type="RSpecRunConfigurationType" factoryName="RSpec" temporary="true">
-      <predefined_log_file id="RUBY_RSPEC" enabled="true" />
-      <module name="gb_working_day" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-      <envs>
-        <env name="JRUBY_OPTS" value="-X+O" />
-      </envs>
-      <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
-      <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
-      <EXTENSION ID="RubyCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" track_test_folders="true" runner="rcov">
-        <COVERAGE_PATTERN ENABLED="true">
-          <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
-        </COVERAGE_PATTERN>
-      </EXTENSION>
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="$MODULE_DIR$/spec/core_ext/time_spec.rb" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="Time extensions should properly add work duration" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="TEST_SCRIPT" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
-      <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
-      <method />
-    </configuration>
+    <shared>
+      <configuration default="false" name="specs" type="RSpecRunConfigurationType" factoryName="RSpec">
+        <module name="gb_working_day" />
+        <predefined_log_file enabled="true" id="RUBY_RSPEC" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
+        <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
+        <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
+          <COVERAGE_PATTERN ENABLED="true">
+            <PATTERN REGEXPS="/.rvm/" INCLUDED="false" />
+          </COVERAGE_PATTERN>
+        </EXTENSION>
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TESTS_FOLDER_PATH" VALUE="$MODULE_DIR$/spec" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_SCRIPT_PATH" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_RUNNER_PATH" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_FILE_MASK" VALUE="**/*_spec.rb" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_EXAMPLE_NAME" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="TEST_TEST_TYPE" VALUE="ALL_IN_FOLDER" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPEC_ARGS" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUNNER_VERSION" VALUE="" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="USE_CUSTOM_SPEC_RUNNER" VALUE="false" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="DRB" VALUE="false" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ZEUS" VALUE="false" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SPRING" VALUE="false" />
+        <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="FULL_BACKTRACE" VALUE="false" />
+        <method v="2" />
+      </configuration>
+    </shared>
   </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
@@ -147,23 +45,26 @@
       <excludeFolder url="file://$MODULE_DIR$/.bundle" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/bundle" />
     </content>
-    <orderEntry type="jdk" jdkName="RVM: ruby-2.3.0" jdkType="RUBY_SDK" />
+    <orderEntry type="jdk" jdkName="RVM: ruby-2.5.1" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="activesupport (v4.2.6, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.2.5, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="docile (v1.1.5, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="i18n (v0.7.0, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.9.0, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rake (v10.5.0, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.1.0, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.1.7, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.1.2, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.1.3, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.1.2, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.10.0, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.10.0, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="thread_safe (v0.3.5, RVM: ruby-2.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v1.2.2, RVM: ruby-2.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activesupport (v5.2.2, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.17.1, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.1.4, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.3, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="docile (v1.3.1, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.3.0, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="json (v2.1.0, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.11.3, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v10.5.0, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.8.2, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.8.0, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.16.1, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.10.2, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="thread_safe (v0.3.6, RVM: ruby-2.5.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v1.2.5, RVM: ruby-2.5.1) [gem]" level="application" />
   </component>
   <component name="RModuleSettingsStorage">
     <LOAD_PATH number="1" string0="$MODULE_DIR$/lib" />

--- a/lib/gb_work_day/core_ext/date.rb
+++ b/lib/gb_work_day/core_ext/date.rb
@@ -25,48 +25,44 @@ class Date
 
   # Check if it is a work day.
   # @return [boolean]
-  def work?
-    default_week.work_day? self
+  def work?(week = default_week)
+    week.work_day? self
   end
 
   # Check if it is a work day.
   # @return [boolean]
-  def free?
-    default_week.free_day? self
+  def free?(week = default_week)
+    week.free_day? self
   end
 
   # Return next working day
   # @return [Time]
-  def next_work_day
-    if default_week.free_day? self
+  def next_work_day(week = default_week)
+    if week.free_day? self
       next_day = self
-      while default_week.free_day? next_day
-        next_day += 1
-      end
+      next_day += 1 while week.free_day? next_day
       next_day
     else
-      self + GBWorkDay::Duration.new(1, default_week)
+      self + GBWorkDay::Duration.new(1, week)
     end
   end
 
   # Return previous working day
   # @return [Time]
-  def previous_work_day
-    if default_week.free_day? self
+  def previous_work_day(week = default_week)
+    if week.free_day? self
       previous_day = self
-      while default_week.free_day? previous_day
-        previous_day -= 1
-      end
+      previous_day -= 1 while week.free_day? previous_day
       previous_day
     else
-      self - GBWorkDay::Duration.new(1, default_week)
+      self - GBWorkDay::Duration.new(1, week)
     end
   end
 
   # Get date object for calculating working days
   #
   # @param week [GBWorkDay::WorkWeek] if not set, it will use week set globally. For more check {GBWorkingDay::WorkWeek#current}
-  def work_date(week=nil)
+  def work_date(week = nil)
     GBWorkDay::Date.from_date self, week
   end
   alias_method :to_work, :work_date

--- a/lib/gb_work_day/core_ext/date.rb
+++ b/lib/gb_work_day/core_ext/date.rb
@@ -49,7 +49,7 @@ class Date
   # @return [Time]
   def previous_work_day(week = default_week)
     if week.free_day? self
-      next_work_day(week) - week.free_days_per_week.days
+      next_work_day(week) - (week.free_days_per_week + 1).days
     else
       self - GBWorkDay::Duration.new(1, week)
     end

--- a/lib/gb_work_day/core_ext/date.rb
+++ b/lib/gb_work_day/core_ext/date.rb
@@ -39,9 +39,7 @@ class Date
   # @return [Time]
   def next_work_day(week = default_week)
     if week.free_day? self
-      next_day = self
-      next_day += 1 while week.free_day? next_day
-      next_day
+      self.beginning_of_week + 7.days
     else
       self + GBWorkDay::Duration.new(1, week)
     end
@@ -51,9 +49,7 @@ class Date
   # @return [Time]
   def previous_work_day(week = default_week)
     if week.free_day? self
-      previous_day = self
-      previous_day -= 1 while week.free_day? previous_day
-      previous_day
+      next_work_day(week) - week.free_days_per_week.days
     else
       self - GBWorkDay::Duration.new(1, week)
     end

--- a/lib/gb_work_day/core_ext/time.rb
+++ b/lib/gb_work_day/core_ext/time.rb
@@ -26,34 +26,44 @@ class Time
 
   # Check if it is a work day.
   # @return [boolean]
-  def work?
-    default_week.work_day? self
+  def work?(week = default_week)
+    week.work_day? self
   end
 
   # Check if it is a work day.
   # @return [boolean]
-  def free?
-    default_week.free_day? self
+  def free?(week = default_week)
+    week.free_day? self
   end
 
   # Return next working day
   # @return [Time]
-  def next_work_day
-    if default_week.free_day? self
+  def next_work_day(week = default_week)
+    if week.free_day? self
       next_day = self
-      while default_week.free_day? next_day
-        next_day += GBWorkDay::Duration::SEC_IN_DAY
-      end
+      next_day += GBWorkDay::Duration::SEC_IN_DAY while week.free_day? next_day
       next_day
     else
-      self + GBWorkDay::Duration.new(1, default_week)
+      self + GBWorkDay::Duration.new(1, week)
+    end
+  end
+
+  # Return previous working day
+  # @return [Time]
+  def previous_work_day(week = default_week)
+    if week.free_day? self
+      previous_day = self
+      previous_day -= GBWorkDay::Duration::SEC_IN_DAY while week.free_day? previous_day
+      previous_day
+    else
+      self - GBWorkDay::Duration.new(1, week)
     end
   end
 
   # Get time object for calculating working days
   #
   # @param week [GBWorkDay::WorkWeek] if not set, it will use week set globally. For more check {GBWorkingDay::WorkWeek#current}
-  def work_time(week=nil)
+  def work_time(week = nil)
     GBWorkDay::Time.from_time self, week
   end
   alias_method :to_work, :work_time

--- a/lib/gb_work_day/core_ext/time.rb
+++ b/lib/gb_work_day/core_ext/time.rb
@@ -40,9 +40,7 @@ class Time
   # @return [Time]
   def next_work_day(week = default_week)
     if week.free_day? self
-      next_day = self
-      next_day += GBWorkDay::Duration::SEC_IN_DAY while week.free_day? next_day
-      next_day
+      self.beginning_of_week + 7.days
     else
       self + GBWorkDay::Duration.new(1, week)
     end
@@ -52,9 +50,7 @@ class Time
   # @return [Time]
   def previous_work_day(week = default_week)
     if week.free_day? self
-      previous_day = self
-      previous_day -= GBWorkDay::Duration::SEC_IN_DAY while week.free_day? previous_day
-      previous_day
+      next_work_day(week) - week.free_days_per_week.days
     else
       self - GBWorkDay::Duration.new(1, week)
     end

--- a/lib/gb_work_day/core_ext/time.rb
+++ b/lib/gb_work_day/core_ext/time.rb
@@ -50,7 +50,7 @@ class Time
   # @return [Time]
   def previous_work_day(week = default_week)
     if week.free_day? self
-      next_work_day(week) - week.free_days_per_week.days
+      next_work_day(week) - (week.free_days_per_week + 1).days
     else
       self - GBWorkDay::Duration.new(1, week)
     end

--- a/lib/gb_work_day/interval.rb
+++ b/lib/gb_work_day/interval.rb
@@ -1,5 +1,8 @@
 require 'gb_work_day/work_week'
 require 'gb_work_day/duration'
+require 'gb_work_day/core_ext/date'
+require 'gb_work_day/core_ext/integer'
+
 module GBWorkDay
   class Interval
     attr_reader :start_time, :end_time
@@ -8,31 +11,37 @@ module GBWorkDay
     # @param end_time [Time, Date]
     # @param params [Hash]
     # @option params [Fixnum] :work_days number of work days in a week, default is 7
-    # @option params [Fixnum] :week_start first working day in a week as number. Default value is 1 corresponding to Monday.
-    def initialize(start_time, end_time, params=Hash.new)
+    def initialize(start_time, end_time, params = Hash.new)
       @start_time = start_time
       @end_time = end_time
       @symbol = 1
       revert if @start_time > @end_time
       @working_week = params[:week]
       unless @working_week
-        if params[:work_days] || params[:week_start]
+        if params[:work_days]
           work_days = params.fetch(:work_days, 7)
-          week_start = params.fetch(:week_start, 1)
-          @working_week = WorkWeek.new work_days, week_start
+          @working_week = WorkWeek.new work_days
         else
           @working_week = WorkWeek.current
         end
       end
+      @work_start_time = next_work_day @start_time
+      @work_end_time = next_work_day @end_time
     end
 
     # @return [Integer] Number of working days in a given period
     def work_days
-      date = @start_time
-      work_days = 0
-      while date < end_time
-        work_days += 1 if @working_week.work_day?(date)
-        date += 1.day
+      if @working_week.work_days_per_week == 7
+        work_days = end_time.minus_without_work_duration(start_time).to_i
+      else
+        monday_before_start = @work_start_time.beginning_of_week
+        monday_before_end   = @work_end_time.beginning_of_week
+
+        full_week_days = monday_before_end.minus_without_work_duration(monday_before_start).to_i
+        days_without_weekends = full_week_days - (full_week_days / 7) * @working_week.free_days_per_week
+        partial_week_days = @work_end_time.wday - @work_start_time.wday
+
+        work_days = days_without_weekends + partial_week_days
       end
       Duration.new(work_days * @symbol, @working_week)
     end
@@ -49,7 +58,18 @@ module GBWorkDay
       new_end_time = @start_time
       @start_time = @end_time
       @end_time = new_end_time
-      @symbol= @symbol * -1
+      @symbol *= -1
+    end
+
+    # Return next working day, or today if today is a working day
+    # @param day [Date, Time]
+    # @return [Date, Time]
+    def next_work_day(day)
+      if @working_week.free_day? day
+        day.next_work_day(@working_week)
+      else
+        day
+      end
     end
   end
 end

--- a/lib/gb_work_day/version.rb
+++ b/lib/gb_work_day/version.rb
@@ -1,3 +1,3 @@
 module GBWorkDay
-  VERSION = '0.0.6'
+  VERSION = '0.1.0'
 end

--- a/lib/gb_work_day/work_week.rb
+++ b/lib/gb_work_day/work_week.rb
@@ -1,15 +1,14 @@
 module GBWorkDay
   class WorkWeek
-    attr_reader :work_days_per_week, :free_days_per_week, :work_days, :free_days, :week_start
+    attr_reader :work_days_per_week, :free_days_per_week, :work_days, :free_days
 
     # @param work_days [#to_i] Amount of working days in a week. Default value is 7.
-    # @param week_start [#to_i] Number of a week day, when work starts. Default value is 1 corresponding to Monday
-    def initialize(work_days=7, week_start=1)
+    def initialize(work_days = 7)
       work_days = work_days.to_i
-      week_start = week_start.to_i
+      week_start = 1
       raise ArgumentError, 'Work days have to be between 0 and 7!' unless work_days >= 0 && work_days <= 7
       @work_days_per_week = work_days
-      @week_start = week_start % 7
+      @week_start = week_start
       @free_days_per_week = 7 - @work_days_per_week
       @work_days = []
       @work_days_per_week.times do
@@ -38,11 +37,11 @@ module GBWorkDay
     end
 
     def ==(other) # :nodoc:
-      work_days_per_week == other.work_days_per_week && week_start == other.week_start
+      work_days_per_week == other.work_days_per_week
     end
 
     def eql?(other) # :nodoc:
-      work_days_per_week.eql?(other.work_days_per_week) && week_start.eql?(other.week_start)
+      work_days_per_week.eql?(other.work_days_per_week)
     end
 
     class << self

--- a/spec/duration_spec.rb
+++ b/spec/duration_spec.rb
@@ -34,10 +34,6 @@ describe GBWorkDay::Duration do
     expect(GBWorkDay::Duration.new(1) == 1).to be_truthy
     expect(GBWorkDay::Duration.new(1) == 2).to be_falsey
 
-    week = GBWorkDay::WorkWeek.new(3, 3)
-    expect(GBWorkDay::Duration.new(1, week) == GBWorkDay::Duration.new(1)).to be_falsey
-    expect(GBWorkDay::Duration.new(1, week) == GBWorkDay::Duration.new(2)).to be_falsey
-
     expect(GBWorkDay::Duration.new(1).eql? GBWorkDay::Duration.new(1)).to be_truthy
     expect(GBWorkDay::Duration.new(1).eql? GBWorkDay::Duration.new(2)).to be_falsey
   end
@@ -57,7 +53,7 @@ describe GBWorkDay::Duration do
   end
 
   it 'should calculate proper time for future' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     monday = Time.now.beginning_of_week
 
     expect(GBWorkDay::Duration.new(1, week).since(monday)).to eq monday + 1.day
@@ -69,7 +65,7 @@ describe GBWorkDay::Duration do
   end
 
   it 'should calculate proper date for future' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     monday = Date.today.beginning_of_week
 
     expect(GBWorkDay::Duration.new(1, week).since(monday)).to eq monday + 1.day
@@ -81,7 +77,7 @@ describe GBWorkDay::Duration do
   end
 
   it 'should calculate proper time for past' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     monday = Time.now.beginning_of_week
 
     expect(GBWorkDay::Duration.new(1, week).until(monday)).to eq monday - 3.days
@@ -92,7 +88,7 @@ describe GBWorkDay::Duration do
   end
 
   it 'should calculate proper date for past' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     monday = Date.today.beginning_of_week
 
     expect(GBWorkDay::Duration.new(1, week).until(monday)).to eq monday - 3.days

--- a/spec/interval_spec.rb
+++ b/spec/interval_spec.rb
@@ -4,7 +4,7 @@ require 'active_support/time'
 
 
 describe GBWorkDay::Interval do
-  it 'properly calculate work days for interval' do
+  it 'properly calculates work days for interval for a 5 days week' do
     week = GBWorkDay::WorkWeek.new(5)
     monday = Date.today.beginning_of_week
     expect(GBWorkDay::Interval.new(monday - 1.day, monday, week: week).duration.work_days).to eq 0
@@ -15,5 +15,27 @@ describe GBWorkDay::Interval do
     expect(GBWorkDay::Interval.new(monday, monday + 7.day, week: week).duration.work_days).to eq 5
     expect(GBWorkDay::Interval.new(monday, monday + 12.day, week: week).duration.work_days).to eq 10
     expect(GBWorkDay::Interval.new(monday, monday + 14.day, week: week).duration.work_days).to eq 10
+  end
+
+  it 'properly calculates work days for interval for a 6 days week' do
+    week = GBWorkDay::WorkWeek.new(6)
+    monday = Date.today.beginning_of_week
+    expect(GBWorkDay::Interval.new(monday - 1.day, monday, week: week).duration.work_days).to eq 0
+    expect(GBWorkDay::Interval.new(monday - 2.day, monday, week: week).duration.work_days).to eq 1
+    expect(GBWorkDay::Interval.new(monday, monday + 1.day, week: week).duration.work_days).to eq 1
+    expect(GBWorkDay::Interval.new(monday, monday + 6.day, week: week).duration.work_days).to eq 6
+    expect(GBWorkDay::Interval.new(monday, monday + 7.day, week: week).duration.work_days).to eq 6
+    expect(GBWorkDay::Interval.new(monday, monday + 12.day, week: week).duration.work_days).to eq 11
+  end
+
+  it 'properly calculates work days for interval for a 7 days week' do
+    week = GBWorkDay::WorkWeek.new(7)
+    monday = Date.today.beginning_of_week
+    expect(GBWorkDay::Interval.new(monday - 1.day, monday, week: week).duration.work_days).to eq 1
+    expect(GBWorkDay::Interval.new(monday - 2.day, monday, week: week).duration.work_days).to eq 2
+    expect(GBWorkDay::Interval.new(monday, monday + 1.day, week: week).duration.work_days).to eq 1
+    expect(GBWorkDay::Interval.new(monday, monday + 6.day, week: week).duration.work_days).to eq 6
+    expect(GBWorkDay::Interval.new(monday, monday + 7.day, week: week).duration.work_days).to eq 7
+    expect(GBWorkDay::Interval.new(monday, monday + 12.day, week: week).duration.work_days).to eq 12
   end
 end

--- a/spec/work_week_spec.rb
+++ b/spec/work_week_spec.rb
@@ -6,65 +6,29 @@ describe GBWorkDay::WorkWeek do
 
   context 'work days' do
     it 'should calculates work days for 7 days work and start on monday' do
-      week = GBWorkDay::WorkWeek.new(7, 1)
+      week = GBWorkDay::WorkWeek.new(7)
       expect(week.work_days).to eq [1,2,3,4,5,6,7]
     end
-
-    it 'should calculates work days for 7 days work and start on tuesday' do
-      week = GBWorkDay::WorkWeek.new(7, 2)
-      expect(week.work_days).to eq [1,2,3,4,5,6,7]
-    end
-
     it 'should calculates work days for 5 days work week and start on monday' do
-      week = GBWorkDay::WorkWeek.new(5, 1)
+      week = GBWorkDay::WorkWeek.new(5)
       expect(week.work_days).to eq [1,2,3,4,5]
-    end
-
-    it 'should calculates work days for 5 days work week and start on tuesday' do
-      week = GBWorkDay::WorkWeek.new(5, 2)
-      expect(week.work_days).to eq [2,3,4,5,6]
-    end
-
-    it 'should calculates work days for 5 days work week and start on thursday' do
-      week = GBWorkDay::WorkWeek.new(5, 4)
-      expect(week.work_days).to eq [1,4,5,6,7]
-    end
-
-    it 'should calculates work days for 3 days work week and start on wednesday' do
-      week = GBWorkDay::WorkWeek.new(3, 3)
-      expect(week.work_days).to eq [3,4,5]
     end
   end
 
   context 'free days' do
-    it 'should calculates free days for 7 days work and start on any day' do
-      week = GBWorkDay::WorkWeek.new(7, rand(6)+1)
+    it 'should calculates free days for 7 days work' do
+      week = GBWorkDay::WorkWeek.new(7)
       expect(week.free_days).to eq []
     end
 
     it 'should calculates free days for 5 days work week and start on monday' do
-      week = GBWorkDay::WorkWeek.new(5, 1)
+      week = GBWorkDay::WorkWeek.new(5)
       expect(week.free_days).to eq [6,7]
-    end
-
-    it 'should calculates work days for 5 days work week and start on tuesday' do
-      week = GBWorkDay::WorkWeek.new(5, 2)
-      expect(week.free_days).to eq [1,7]
-    end
-
-    it 'should calculates work days for 5 days work week and start on thursday' do
-      week = GBWorkDay::WorkWeek.new(5, 4)
-      expect(week.free_days).to eq [2,3]
-    end
-
-    it 'should calculates work days for 3 days work week and start on wednesday' do
-      week = GBWorkDay::WorkWeek.new(3, 3)
-      expect(week.free_days).to eq [1,2,6,7]
     end
   end
 
   it 'should respond to work_day? if day is a Time' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     expect(week.work_days).to eq [1,2,3,4,5]
     monday = Time.now.beginning_of_week
 
@@ -79,7 +43,7 @@ describe GBWorkDay::WorkWeek do
   end
 
   it 'should respond to work_day? if day is a Date' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     expect(week.work_days).to eq [1,2,3,4,5]
     monday = Date.today.beginning_of_week
 
@@ -93,7 +57,7 @@ describe GBWorkDay::WorkWeek do
   end
 
   it 'should respond to free_day? if day is a Time' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     expect(week.free_days).to eq [6,7]
     monday = Time.now.beginning_of_week
 
@@ -107,7 +71,7 @@ describe GBWorkDay::WorkWeek do
   end
 
   it 'should respond to free_day? if day is a Date' do
-    week = GBWorkDay::WorkWeek.new(5, 1)
+    week = GBWorkDay::WorkWeek.new(5)
     expect(week.free_days).to eq [6,7]
     monday = Date.today.beginning_of_week
 


### PR DESCRIPTION
- Add support for week other than default week in Integer/Date/Time monkey-patches
- Add support for adding days to non-work days
- Remove support for week start other than Monday for the sake of simplicity of calculations
- `date1 - date2` work days interval calculation now in O(1) instead of O(N)
- Next day calculation is now O(1)